### PR TITLE
Сlamp springLowerForce to avoid joint creation error.

### DIFF
--- a/LowLevel/Packages/com.unity.2d.physics.lowlevelextras/Runtime/Joints/SceneDistanceJoint.cs
+++ b/LowLevel/Packages/com.unity.2d.physics.lowlevelextras/Runtime/Joints/SceneDistanceJoint.cs
@@ -26,6 +26,9 @@ namespace UnityEngine.U2D.Physics.LowLevelExtras
             if (JointDefinition.minDistanceLimit > JointDefinition.maxDistanceLimit)
                 JointDefinition.minDistanceLimit = JointDefinition.maxDistanceLimit;
 
+            if (JointDefinition.springLowerForce > JointDefinition.springUpperForce)
+                JointDefinition.springLowerForce = JointDefinition.springUpperForce;
+
             // Create the joint.
             m_Joint = PhysicsDistanceJoint.Create(BodyA.Body.world, JointDefinition);
             if (m_Joint.isValid)


### PR DESCRIPTION
Added a check in SceneDistanceJoint to ensure springLowerForce <= springUpperForce.
Prevents a joint creation error.